### PR TITLE
Version 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.yml
 geodatautils.egg-info
 
 temp/*
+.vscode/*

--- a/geodatautils/__init__.py
+++ b/geodatautils/__init__.py
@@ -4,7 +4,7 @@ A set of utilities to manage the Wisconsin Geodata Geoblacklight instance.
 """
 
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __author__ = "Hayden Elza"
 __license__ = "GPL-3"
 

--- a/geodatautils/__init__.py
+++ b/geodatautils/__init__.py
@@ -4,7 +4,7 @@ A set of utilities to manage the Wisconsin Geodata Geoblacklight instance.
 """
 
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Hayden Elza"
 __license__ = "GPL-3"
 

--- a/geodatautils/__init__.py
+++ b/geodatautils/__init__.py
@@ -4,7 +4,7 @@ A set of utilities to manage the Wisconsin Geodata Geoblacklight instance.
 """
 
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "Hayden Elza"
 __license__ = "GPL-3"
 

--- a/geodatautils/config/config-template.yml
+++ b/geodatautils/config/config-template.yml
@@ -19,7 +19,7 @@ error-checks:
   identifier-layer-slug-match: true
   temporal-contains-solr-year: true
   title-contains-solr-year: true
-  references-contains-solr-year: true
+  references-contains-solr-year: false
   existing-uid: true
 
 log:

--- a/geodatautils/config/config-template.yml
+++ b/geodatautils/config/config-template.yml
@@ -17,8 +17,8 @@ solr instances:
 error-checks:
   properties-not-null: ["dc_title_s", "dc_identifier_s", "layer_slug_s", "solr_geom", "dct_provenance_s", "dc_rights_s", "geoblacklight_version", "dc_creator_sm", "dc_description_s", "dct_references_s", "dct_temporal_sm", "solr_year_i", "layer_modified_dt"]
   identifier-layer-slug-match: true
-  temporal-contains-solr-year: true
-  title-contains-solr-year: true
+  temporal-contains-solr-year: false
+  title-contains-solr-year: false
   references-contains-solr-year: false
   existing-uid: true
 

--- a/geodatautils/config/config-template.yml
+++ b/geodatautils/config/config-template.yml
@@ -17,9 +17,6 @@ solr instances:
 error-checks:
   properties-not-null: ["dc_title_s", "dc_identifier_s", "layer_slug_s", "solr_geom", "dct_provenance_s", "dc_rights_s", "geoblacklight_version", "dc_creator_sm", "dc_description_s", "dct_references_s", "dct_temporal_sm", "solr_year_i", "layer_modified_dt"]
   identifier-layer-slug-match: true
-  temporal-contains-solr-year: false
-  title-contains-solr-year: false
-  references-contains-solr-year: false
   existing-uid: true
 
 log:

--- a/geodatautils/helpers.py
+++ b/geodatautils/helpers.py
@@ -159,4 +159,10 @@ def open_json(file_path:str) -> dict:
     """Given a file path to a JSON file, return the JSON loaded into a dictionary."""
 
     with open(file_path, encoding="utf8") as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.decoder.JSONDecodeError as e:
+            logging.critical("Could not decode JSON: {}".format(file_path))
+            logging.debug(e)
+            logging.info("Exiting; see log for debug.")
+            raise SystemExit

--- a/geodatautils/helpers.py
+++ b/geodatautils/helpers.py
@@ -8,6 +8,7 @@ import os
 import logging
 import glob
 import json
+from typing import Union, ClassVar
 
 from .logging_config import LogFormat
 
@@ -15,7 +16,7 @@ from .logging_config import LogFormat
 class Error:
     """An error contains an error message and a debug message."""
 
-    def __init__(self, label:str, msg:str, debug:str):
+    def __init__(self, label:str, msg:str, debug:Union[str, None]):
         self.label = label
         self.msg = msg
         self.debug = debug
@@ -23,60 +24,109 @@ class Error:
 class Record:
     """Defines a record with a file path and data (JSON contents)."""
 
-    def __init__(self, data:dict, filepath:str=None) -> None:
+    def __init__(self, data: dict, filepath: Union[str, None] = None, set_counts: Union[dict, None] = None) -> None:
         self.filepath = filepath
         self.data = data
         self.errors = []
         self.warnings = []
+        self.set_counts = set_counts
 
     @property
-    def has_errors(self) -> bool:
-        """True if record has errors."""
-        return (True if self.errors else False)
+    def has_errors(self) -> int:
+        """Returns error count for record."""
+        return len(self.errors)
     
     @property
-    def has_warnings(self) -> bool:
-        """True if record has warnings."""
-        return (True if self.warnings else False)
+    def has_warnings(self) -> int:
+        """Returns warning count for record."""
+        return len(self.warnings)
 
-    def add_error(self, label:str, msg:str, debug:str):
+    def add_error(self, label:str, msg:str, debug:Union[str, None]):
         """Add an error to the record."""
         self.errors.append(Error(label, msg, debug))
+        self.set_counts['errors'] += 1
     
     def add_warning(self, label:str, msg:str, debug:str):
         """Add an warning to the record."""
         self.warnings.append(Error(label, msg, debug))
+        self.set_counts['warnings'] += 1
 
-    def log_record(self, level:str="debug"):
+    def log_record(self, level: str = "debug", indent: int = 1):
         """Log the file name of the record."""
         if level == "info":
-            logging.info(self.filepath, extra={'indent': LogFormat.indent(1)})
+            logging.info(self.filepath, extra={'indent': LogFormat.indent(indent)})
         elif level == "debug":
-            logging.debug(self.filepath, extra={'indent': LogFormat.indent(1)})
+            logging.debug(self.filepath, extra={'indent': LogFormat.indent(indent)})
         else:
             print("Level '{}' is not recognized. Must be 'info' or 'debug'.")
 
-    def log_errors(self):
+    def log_errors(self, indent: int = 2):
         """Write errors to log."""
 
-        self.log_record(level="info")
+        self.log_record(level="info", indent=indent)
         
         for error in self.errors:
             if error.msg: 
-                logging.error(error.msg, extra={'indent': LogFormat.indent(2, True), 'label': LogFormat.label(error.label)})
+                logging.error(error.msg, extra={'indent': LogFormat.indent(indent+1, True), 'label': LogFormat.label(error.label)})
             if error.debug:
-                logging.debug(error.debug, extra={'indent': LogFormat.indent(3)})
+                logging.debug(error.debug, extra={'indent': LogFormat.indent(indent+3)})
     
-    def log_warnings(self):
+    def log_warnings(self, indent: int = 2):
         """Write warnings to log."""
 
-        self.log_record(level="info")
+        self.log_record(level="info", indent=indent)
         
         for warning in self.warnings:
             if warning.msg: 
-                logging.warning(warning.msg, extra={'indent': LogFormat.indent(2, True), 'label': LogFormat.label(warning.label)})
+                logging.warning(warning.msg, extra={'indent': LogFormat.indent(indent+1, True), 'label': LogFormat.label(warning.label)})
             if warning.debug:
-                logging.debug(warning.debug, extra={'indent': LogFormat.indent(3)})
+                logging.debug(warning.debug, extra={'indent': LogFormat.indent(indent+3)})
+
+class RecordSet:
+    """A set of multiple Records.
+    
+    Attributes:
+    records (dict[str, Record]) -- A dictionary with UID as the key and a Record object as the value.
+    counts (dict[str, int]) -- A dictionary storing the counts for errors and warnings.
+    """
+
+    records: dict[str, Record] = {}
+
+    def __init__(self) -> None:
+        self.counts = {
+            'errors': 0,
+            'warnings': 0
+        }
+
+    def add_record(self, data, filepath) -> None:
+        self.records[data['dc_identifier_s']] = Record(data, filepath=filepath, set_counts=self.counts)
+
+    def log_errors_and_warnings(self, indent: int = 0) -> None:
+        """Log errors and warnings for each record in set."""
+
+        # Initialize stores
+        records_with_errors = []
+        records_with_warnings = []
+
+        # Collect record uids with errors or warnings
+        for uid, record in self.records.items():
+            if record.has_errors:
+                records_with_errors.append(uid)
+            if record.has_warnings:
+                records_with_warnings.append(uid)
+
+        # Begin logging
+        logging.info("Error and Warning Summary:", extra={'indent': LogFormat.indent(indent)})
+        
+        # Log errors
+        logging.info("{} Error{}{}".format(len(records_with_errors), ("" if len(records_with_errors)==1 else "s"), ("" if len(records_with_errors)==0 else ":")), extra={'indent': LogFormat.indent(indent+1)})
+        for uid in records_with_errors:
+            self.records[uid].log_errors(indent=indent+2)
+
+        # Log warnings
+        logging.info("{} Warning{}{}".format(len(records_with_warnings), ("" if len(records_with_warnings)==1 else "s"), ("" if len(records_with_warnings)==0 else ":")), extra={'indent': LogFormat.indent(indent+1)})
+        for uid in records_with_warnings:
+            self.records[uid].log_warnings(indent=indent+2)
 
 def create_file_list(in_path:str) -> list:
     """Given a path that could be a file or directory, return a list of all 

--- a/geodatautils/interfaces.py
+++ b/geodatautils/interfaces.py
@@ -74,7 +74,7 @@ def update_solr():
         action='store_true',
         help="Delete the entire Solr index.")
 
-    # Optoinal arguments
+    # Optional arguments
     parser.add_argument(
         "-r", "--recursive",
         action='store_true',

--- a/geodatautils/logging_config.py
+++ b/geodatautils/logging_config.py
@@ -21,14 +21,17 @@ class DefaultIndent(logging.Filter, ):
 class LogFormat:
     """Helper class to format log entries."""
 
-    def indent(level, tree=False):
+    @staticmethod
+    def indent(level:int, tree:bool=False):
         """Indent with tabs with the option of a tree prefix."""
         return "\t"*level*2 + ("└── " if tree else "")
 
+    @staticmethod
     def label(label:str):
         """Add label to log entry. E.g., '(some-function)'"""
         return "(" + label + ") "
     
+    @staticmethod
     def spaces(n):
         """Generate a specified number of spaces."""
         return " "*n

--- a/geodatautils/logging_config.py
+++ b/geodatautils/logging_config.py
@@ -24,7 +24,7 @@ class LogFormat:
     @staticmethod
     def indent(level:int, tree:bool=False):
         """Indent with tabs with the option of a tree prefix."""
-        return "\t"*level*2 + ("└── " if tree else "")
+        return ("\t"*level if level else " ") + ("└── " if tree else "")
 
     @staticmethod
     def label(label:str):

--- a/geodatautils/manage.py
+++ b/geodatautils/manage.py
@@ -4,7 +4,7 @@ Manage Solr instance by updating the index.
 """
 
 
-__version__ = 2.0
+__version__ = 3.0
 
 
 import logging

--- a/geodatautils/manage.py
+++ b/geodatautils/manage.py
@@ -10,7 +10,7 @@ __version__ = 2.0
 import logging
 
 from geodatautils import config
-from .helpers import create_file_list, open_json, Record
+from .helpers import create_file_list, open_json, RecordSet
 from .logging_config import LogFormat
 from .solr import Solr
 from . import schema
@@ -23,7 +23,7 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
     errors = False
 
     # Initialize records store
-    records = {}
+    record_set = RecordSet()
 
     # Initialize solr instance
     solr = Solr(solr_instance_name)
@@ -43,16 +43,19 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
         # Open the file
         data = open_json(filepath)
 
-        # Add record to records -> uid: Record()
-        records[data['dc_identifier_s']] = Record(data, filepath=filepath)
+        # Add record to record set
+        record_set.add_record(data, filepath)
 
     # Validate schema of records
     logging.info("Validating schema of {} documents.".format(len(file_list)))
-    errors = schema.validate(records, metadata_schema) or errors
+    errors = schema.validate(record_set, metadata_schema) or errors
 
     # Check for errors in records
     logging.info("Checking {} documents for errors.".format(len(file_list)))
-    errors = schema.error_check(records, solr) or errors
+    errors = schema.error_check(record_set, solr) or errors
+
+    # Log errors and warnings
+    record_set.log_errors_and_warnings(indent=1)
 
     # Upload records if no errors
     if not errors:
@@ -70,15 +73,13 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
             logging.info("Uploading {} document{} to {}.".format(len(file_list), ("" if len(file_list)==1 else "s"), solr_instance_name))
 
         # Log file names that will be uploaded
-        for file_name in file_list:
-            
-            # Log the file path
-            logging.debug(file_name, extra={'indent': LogFormat.indent(1)})
+        for record in record_set.records.values():
+            record.log_record(level='debug', indent=2)
 
         # Update solr index
         """Note: there is a risk of a time-of-check time-of-use (TOCTOU) error with this code
         structure because we check Solr for duplicates and later upload."""
-        data = list(map(lambda record: record.data, records))
+        data = str(list(map(lambda record: record.data, record_set.records.values()))).encode()
         raw_response = solr.update(data)
 
         # Raise any errors

--- a/geodatautils/manage.py
+++ b/geodatautils/manage.py
@@ -22,8 +22,8 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
     # Initialize error tracker, tracks if any errors have been found. If so, program will stop before pushing to solr
     errors = False
 
-    # Initialize records store, store records so they can be uploaded at the end
-    records = []
+    # Initialize records store
+    records = {}
 
     # Initialize solr instance
     solr = Solr(solr_instance_name)
@@ -43,8 +43,8 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
         # Open the file
         data = open_json(filepath)
 
-        # Add record to records
-        records.append(Record(data, filepath=filepath))
+        # Add record to records -> uid: Record()
+        records[data['dc_identifier_s']] = Record(data, filepath=filepath)
 
     # Validate schema of records
     logging.info("Validating schema of {} documents.".format(len(file_list)))

--- a/geodatautils/schema.py
+++ b/geodatautils/schema.py
@@ -90,26 +90,6 @@ def error_check(record_set:RecordSet, solr:Solr) -> bool:
         if config['error-checks'][error_check_name] and not empty_missing(data, ['dc_identifier_s', 'layer_slug_s']):
             if data['dc_identifier_s'] != data['layer_slug_s']:
                 record.add_error(error_check_name, "'dc_identifier_s' and 'layer_slug_s' do not match", "'{}', '{}'".format(data['dc_identifier_s'], data['layer_slug_s']))
-                
-
-        # Check that dct_temporal_sm contains solr_year_i
-        error_check_name = 'temporal-contains-solr-year'
-        if config['error-checks'][error_check_name] and not empty_missing(data, ['solr_year_i', 'dct_temporal_sm']):
-            if not any(str(data['solr_year_i']) in item for item in data['dct_temporal_sm']):
-                record.add_error(error_check_name, "'dct_temporal_sm' does not contain 'solr_year_i'", "'{}', '{}'".format(data['dct_temporal_sm'], data['solr_year_i']))
-
-        # Check that dc_title_s contains solr_year_i 
-        error_check_name = 'title-contains-solr-year'
-        if config['error-checks'][error_check_name] and not empty_missing(data, ['solr_year_i', 'dc_title_s']):
-            if str(data['solr_year_i']) not in data['dc_title_s']:
-                record.add_error(error_check_name, "'dc_title_s' does not contain 'solr_year_i'", "'{}', '{}'".format(data['dc_title_s'], data['solr_year_i']))
-
-        # Check that dct_references_s contains solr_year_i
-        error_check_name = 'references-contains-solr-year'
-        if config['error-checks'][error_check_name] and not empty_missing(data, ['solr_year_i', 'dct_references_s']):
-
-            if not str(data['solr_year_i']) in data['dct_references_s']:
-                record.add_warning(error_check_name, """'dct_references_s' does not contain 'solr_year_i'""", "{}, '{}'".format(data['dct_references_s'], data['solr_year_i']))
         
         if record.has_errors:
             errors = True

--- a/geodatautils/schema.py
+++ b/geodatautils/schema.py
@@ -45,11 +45,11 @@ def empty_missing(data:dict, fields:Union[str, list]) -> str:
     # If no fields are empty or missing
     return None
 
-def error_check(records:list[Record], solr:Solr) -> bool:
+def error_check(records:dict[str, Record], solr:Solr) -> bool:
     """Check for errors in a GeoBlacklight JSON file.
     
     Arguments:
-    records (list[Record]) -- a list of Solr records
+    records (dict[str, Record]) -- a list of Solr records
     solr (Solr) -- initilized solr object (geodatautils.solr.Solr)
 
     Returns:
@@ -62,7 +62,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
     errors = False
 
     # For each record run checks
-    for record in records:
+    for uid, record in records.items():
 
         data = record.data
 
@@ -122,7 +122,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
     if config['error-checks'][error_check_name]:
 
         # Check that no UIDs are empty or missing
-        if any(map(lambda record: empty_missing(record.data, ['dc_identifier_s']), records)):
+        if any(map(lambda record: empty_missing(record.data, ['dc_identifier_s']), records.values())):
             logging.error("Aborted UID check because at least one UID is empty or missing from an input record.", extra={'indent': LogFormat.indent(1), 'label': LogFormat.label(error_check_name)})
             errors = True
 
@@ -130,7 +130,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
         else:
             
             # Build UID list
-            uid_list = list(map(lambda record: record.data['dc_identifier_s'], records))
+            uid_list = list(map(lambda record: record.data['dc_identifier_s'], records.values()))
 
             # Initialize records store
             records_found = []
@@ -164,7 +164,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
 
     return errors
 
-def validate(records:list[Record], schema_name:str) -> bool:
+def validate(records:dict[str, Record], schema_name:str) -> bool:
     """Validate GeoBlacklight JSON schema.
     
     Returns:
@@ -176,7 +176,7 @@ def validate(records:list[Record], schema_name:str) -> bool:
     errors = False
 
     # Validate each record
-    for record in records:
+    for uid, record in records.items():
 
         data = record.data
 

--- a/geodatautils/schema.py
+++ b/geodatautils/schema.py
@@ -18,7 +18,7 @@ from .logging_config import LogFormat
 from .solr import Solr
 
 
-def empty_missing(data:dict, fields:Union[str, list]) -> str:
+def empty_missing(data:dict, fields:Union[str, list]) -> Union[str, None]:
     """Check if a required fields are present in geoblacklight JSON.
 
     Arguments:
@@ -36,7 +36,7 @@ def empty_missing(data:dict, fields:Union[str, list]) -> str:
     # Check each field to see if it is empty or missing
     for field in fields:
         try:
-            if data[field] == "":
+            if data[field] in ["", [], [""]]:
                 return "empty"
         
         except KeyError:
@@ -79,11 +79,13 @@ def error_check(record_set:RecordSet, solr:Solr) -> bool:
                     # Compose message
                     if error == "empty":
                         msg = "'{}' is empty".format(field)
+                        debug = "{}: {} (\"\", [], and [\"\"] are considered empty)".format(field, data[field])
                     elif error == "missing":
                         msg = "Required field '{}' was not found.".format(field)
+                        debug = None
 
                     # Add error to record
-                    record.add_error('properties-not-null', msg, None)        
+                    record.add_error('properties-not-null', msg, debug)        
 
         # Check that dc_identifier_s and layer_slug_s match
         error_check_name = 'identifier-layer-slug-match'

--- a/geodatautils/schema.py
+++ b/geodatautils/schema.py
@@ -151,7 +151,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
 
                 # Store any matching records for logging later
                 if raw_response.json()['response']['numFound']:
-                    records_found.append([doc['dc_identifier_s'] for doc in raw_response.json()['response']['docs']])
+                    records_found.extend([doc['dc_identifier_s'] for doc in raw_response.json()['response']['docs']])
 
             # Error if any matching records are found
             if records_found:

--- a/geodatautils/schema.py
+++ b/geodatautils/schema.py
@@ -122,7 +122,12 @@ def error_check(records:list[Record], solr:Solr) -> bool:
     if config['error-checks'][error_check_name]:
 
         # Check that no UIDs are empty or missing
-        if not any(map(lambda record: empty_missing(record.data, ['dc_identifier_s']), records)):
+        if any(map(lambda record: empty_missing(record.data, ['dc_identifier_s']), records)):
+            logging.error("Aborted UID check because at least one UID is empty or missing from an input record.", extra={'indent': LogFormat.indent(1), 'label': LogFormat.label(error_check_name)})
+            errors = True
+
+        # Proceed normally
+        else:
             
             # Build UID list
             uid_list = list(map(lambda record: record.data['dc_identifier_s'], records))
@@ -155,11 +160,7 @@ def error_check(records:list[Record], solr:Solr) -> bool:
                 for record_uid in records_found:
                     logging.debug(record_uid, extra={'indent': LogFormat.indent(2, tree=True)})
                 
-                errors = True
-    
-        else:
-            logging.error("Aborted UID check because at least one UID is empty or missing from an input record.", extra={'indent': LogFormat.indent(1), 'label': LogFormat.label(error_check_name)})
-            errors = True
+                errors = True       
 
     return errors
 

--- a/geodatautils/solr.py
+++ b/geodatautils/solr.py
@@ -80,7 +80,7 @@ class Solr:
 
         return raw_response
     
-    def update(self, data:str, commit:bool=True) -> requests.models.Response:
+    def update(self, data:bytes, commit:bool=True) -> requests.models.Response:
         """Use supplied list of records to update Solr instance."""
 
         # Build parameters
@@ -100,6 +100,6 @@ class Solr:
         headers = {"Content-Type":"application/json"}
         
         # Post records to solr
-        raw_response = requests.post(update_url, data=str(data).encode(), headers=headers, auth=(self.username, self.password))
+        raw_response = requests.post(update_url, data=data, headers=headers, auth=(self.username, self.password))
         
         return raw_response


### PR DESCRIPTION
# Version 1.3

Remove `solr_year_i` error checks; Duplicate UID is warning not error

## Update Procedure

1. Make sure you are in your `geodata-utils` environment:

    ```bash
    activate geodata-utils
    ```

2. Then run the following to update the library:

    ```bash
    python -m pip install --upgrade https://github.com/WIStCart/geodata-utils/archive/main.tar.gz
    ```
3. Edit your config file by running:
    ```bash
    gu_config -e
    ```
    Remove the following lines from your config:
    ```yaml
    temporal-contains-solr-year: true
    title-contains-solr-year: true
    references-contains-solr-year: true
    ```
    Save and close the config file.

## Changes
- Added concept of record sets
- Improved type hinting and method decoration
- Duplicate UIDs are now warnings instead of errors, allowing the user to ignore the warning and continue anyway
- Removed `solr_year_i` checks as they are no longer needed