### PR TITLE
Version 1.4

### DIFF
--- a/geodatautils/__init__.py
+++ b/geodatautils/__init__.py
@@ -4,7 +4,7 @@ A set of utilities to manage the Wisconsin Geodata Geoblacklight instance.
 """
 
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Hayden Elza"
 __license__ = "GPL-3"
 

--- a/geodatautils/__init__.py
+++ b/geodatautils/__init__.py
@@ -4,7 +4,7 @@ A set of utilities to manage the Wisconsin Geodata Geoblacklight instance.
 """
 
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"
 __author__ = "Hayden Elza"
 __license__ = "GPL-3"
 

--- a/geodatautils/interfaces.py
+++ b/geodatautils/interfaces.py
@@ -7,7 +7,7 @@ Command line interfaces for Geodata utilites.
 import argparse
 import logging
 
-from geodatautils import config
+from geodatautils import config, __version__
 from . import config_tools
 from . import manage
 
@@ -81,7 +81,7 @@ def update_solr():
         help="[Deprecated] Recurse into subfolders when adding JSON files.")
 
     # Print version
-    parser.add_argument("--version", action="version", version="%(prog)s - Version {}".format(manage.__version__))
+    parser.add_argument("--version", action="version", version="Geodata Utils - Version {}".format(__version__))
 
     # Parse arguments
     args = parser.parse_args()

--- a/geodatautils/manage.py
+++ b/geodatautils/manage.py
@@ -43,6 +43,19 @@ def add(in_path:str, solr_instance_name:str, confirm_action:bool=False, metadata
         # Open the file
         data = open_json(filepath)
 
+        # Check if record UID already exists in record set
+        if data['dc_identifier_s'] in record_set.records.keys():
+
+            # Add error to record
+            msg = "Another input file has the same UID and could not be opened."
+            debug = "'{}'".format(filepath)
+            record_set.records[data['dc_identifier_s']].add_error('uid-collision', msg, debug)
+
+            errors = True
+
+            # Skip adding record to set
+            continue
+
         # Add record to record set
         record_set.add_record(data, filepath)
 

--- a/geodatautils/manage.py
+++ b/geodatautils/manage.py
@@ -4,9 +4,6 @@ Manage Solr instance by updating the index.
 """
 
 
-__version__ = 3.0
-
-
 import logging
 
 from geodatautils import config


### PR DESCRIPTION
# Version 1.4

Added check for duplicate UIDs in input records.

## Update Procedure

1. Make sure you are in your `geodata-utils` environment:

    ```bash
    activate geodata-utils
    ```

2. Then run the following to update the library:

    ```bash
    python -m pip install --upgrade https://github.com/WIStCart/geodata-utils/archive/main.tar.gz
    ```
   You should see `Successfully installed geodatautils-1.4.1`

## Changes
- Added check for duplicate UIDs in input records
- Removed `manage.py` version number

## Issues
- Resolves #7.

## Testing
- [x] Installs
- [x] Passes [tests](https://docs.google.com/spreadsheets/d/18MQwbXvH8VOroO92TSs5QFzxvWgS2tSswAV-n62zrDQ/edit#gid=305373290)